### PR TITLE
feat(chore): remove support for node v14,v12,v10,v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=8.9"
+        "node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=16"
   },
   "scripts": {
     "build": "npm run clean && lb-tsc",


### PR DESCRIPTION
## Description
- Version 14, v12, v10, v8 of Nodejs reached its end of life

- BREAKING CHANGE:
End of life of node v14, node v12 and node v10

GH-78

Fixes #78

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
